### PR TITLE
refactor: 요청 타입 enum활용하도록 변경

### DIFF
--- a/src/main/java/com/example/parsing/controller/ParsingRestController.java
+++ b/src/main/java/com/example/parsing/controller/ParsingRestController.java
@@ -7,10 +7,7 @@ import com.example.parsing.utils.ApiUtils.ApiResult;
 import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -27,13 +24,14 @@ public class ParsingRestController {
     @ApiOperation(value = "URL 호출 결과 Parsing", notes = "URL 호출 결과를 Parsing 하여 반환하는 API")
     @ApiImplicitParams({
             @ApiImplicitParam(name = "url", value = "요청 URL", required = true),
-            @ApiImplicitParam(name = "type", value = "1 = HTML 태그 제외, 2 = TEXT 전체", required = true),
+            @ApiImplicitParam(name = "type", value = "REMOVE_HTML = HTML 태그 제외, ALL_TEXT = TEXT 전체", required = true),
             @ApiImplicitParam(name = "unit", value = "결과 데이터를 나누는 단위", required = true)
     })
     @PostMapping(value = "/parsing",
                 consumes=MediaType.APPLICATION_FORM_URLENCODED_VALUE,
                 produces = MediaType.APPLICATION_JSON_VALUE)
     public ApiResult<ParsingDto> parsing_api(@Valid FormData formData) {
+        System.out.println(formData.getType().getClass());
         return success(parsingService.parse(formData));
     }
 }

--- a/src/main/java/com/example/parsing/domain/FormData.java
+++ b/src/main/java/com/example/parsing/domain/FormData.java
@@ -1,6 +1,6 @@
 package com.example.parsing.domain;
 
-import io.swagger.models.auth.In;
+import com.example.parsing.validation.EnumValid;
 import lombok.*;
 import org.hibernate.validator.constraints.Range;
 
@@ -11,8 +11,8 @@ import javax.validation.constraints.NotBlank;
 public class FormData {
     @NotBlank(message = "Url must be exist")
     private String url;
-    @Range(min = 1, max = 2, message = "Type 1(remove tag) or 2(all) only")
-    private Integer type;
     @Range(min = 1, max = 10000000, message = "Unit Please a number greater than 1 and less than 1000000")
     private Integer unit;
+    @EnumValid(enumClass = ParsingType.class, message = "Invalid Parsing Type")
+    private String type;
 }

--- a/src/main/java/com/example/parsing/domain/ParsingDto.java
+++ b/src/main/java/com/example/parsing/domain/ParsingDto.java
@@ -1,6 +1,5 @@
 package com.example.parsing.domain;
 
-import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/parsing/domain/ParsingType.java
+++ b/src/main/java/com/example/parsing/domain/ParsingType.java
@@ -1,0 +1,14 @@
+package com.example.parsing.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ParsingType {
+    REMOVE_HTML("REMOVE_HTML"),
+    ALL_TEXT("ALL_TEXT");
+
+    String value;
+    ParsingType(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/com/example/parsing/utils/UrlConnectionJsoup.java
+++ b/src/main/java/com/example/parsing/utils/UrlConnectionJsoup.java
@@ -1,5 +1,6 @@
 package com.example.parsing.utils;
 
+import com.example.parsing.domain.ParsingType;
 import com.example.parsing.errors.UrlConnectException;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
@@ -17,12 +18,12 @@ public class UrlConnectionJsoup {
         return Jsoup.parse(data).text();
     }
 
-    public String getUrlDataJsoup(String url, int type) {
+    public String getUrlDataJsoup(String url, String type) {
         String errMsg = " invalid URL";
         try {
             Document doc = Jsoup.connect(url).get();
             String data = doc.toString();
-            if (type == 1)
+            if (type.equals(ParsingType.REMOVE_HTML.getValue()))
                 data = removeHtml(data);
             return data;
         } catch (IOException e) {

--- a/src/main/java/com/example/parsing/validation/EnumValid.java
+++ b/src/main/java/com/example/parsing/validation/EnumValid.java
@@ -1,0 +1,22 @@
+package com.example.parsing.validation;
+
+import com.example.parsing.domain.ParsingType;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+// 해당 annotation이 실행 할 ConstraintValidator 구현체를 `EnumValidator`로 지정합니다
+@Constraint(validatedBy = {EnumValidator.class})
+// 해당 annotation은 메소드, 필드, 파라미터에 적용 가능
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnumValid {
+    String message() default "Invalid Type.";
+    Class<? extends java.lang.Enum<?>> enumClass();
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/example/parsing/validation/EnumValidator.java
+++ b/src/main/java/com/example/parsing/validation/EnumValidator.java
@@ -1,0 +1,27 @@
+package com.example.parsing.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class EnumValidator implements ConstraintValidator<EnumValid, String> {
+
+    private List<String> acceptedValues;
+
+    @Override
+    public void initialize(EnumValid annotation) {
+        acceptedValues = Stream.of(annotation.enumClass().getEnumConstants())
+                .map(Enum::name)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null || value.isEmpty()) {
+            return false;
+        }
+        return acceptedValues.contains(value);
+    }
+}

--- a/src/test/java/com/example/parsing/controller/ParsingRestControllerTest.java
+++ b/src/test/java/com/example/parsing/controller/ParsingRestControllerTest.java
@@ -1,6 +1,8 @@
 package com.example.parsing.controller;
 
+import com.example.parsing.domain.FormData;
 import com.example.parsing.domain.ParsingDto;
+import com.example.parsing.domain.ParsingType;
 import com.example.parsing.utils.DataParser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Assertions;
@@ -34,10 +36,11 @@ class ParsingRestControllerTest {
         mockMvc.perform(post("/parsing")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .accept(MediaType.APPLICATION_JSON)
-                 .param("url", "https://naver.com")
-                .param("type", "1")
+                .param("url", "https://naver.com")
+                .param("type", ParsingType.REMOVE_HTML.getValue())
                 .param("unit", "30"))
-        .andDo(print())
+                //.content(objectMapper.writeValueAsString(formData)))
+                .andDo(print())
         //then
         .andExpect(status().isOk())
         .andExpect(jsonPath("success").exists())
@@ -63,7 +66,7 @@ class ParsingRestControllerTest {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .accept(MediaType.APPLICATION_JSON)
                 .param("url", url)
-                .param("type", "1")
+                .param("type", ParsingType.REMOVE_HTML.getValue())
                 .param("unit", "30"))
                 //.andDo(print())
                 //then
@@ -76,15 +79,16 @@ class ParsingRestControllerTest {
 
     private static Object[] provideForTestWrongType() {
         return new Object[]{
-                new Object[]{"0"},
+                new Object[]{"Hi"},
                 new Object[]{"-1"},
+                new Object[]{"0"},
+                new Object[]{"1"},
                 new Object[]{"1000000"},
         };
     }
     @ParameterizedTest()
     @MethodSource("provideForTestWrongType")
     public void api_호출_잘못된_type_입력(String type) throws Exception {
-        String errMsg = "Type 1(remove tag) or 2(all) only";
         // given, when
         mockMvc.perform(post("/parsing")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
@@ -93,7 +97,6 @@ class ParsingRestControllerTest {
                 .param("type", type)
                 .param("unit", "100"))
                 .andExpect(jsonPath("error.message").exists())
-                .andExpect(jsonPath("error.message").value(errMsg))
                 // .andDo(print())
                 //then
                 .andExpect(status().isBadRequest())
@@ -117,7 +120,7 @@ class ParsingRestControllerTest {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .accept(MediaType.APPLICATION_JSON)
                 .param("url", "https://naver.com")
-                .param("type", "1")
+                .param("type", ParsingType.REMOVE_HTML.getValue())
                 .param("unit", unit))
                 .andExpect(jsonPath("error.message").exists())
                 .andExpect(jsonPath("error.message").value(errMsg))
@@ -178,7 +181,7 @@ class ParsingRestControllerTest {
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .accept(MediaType.APPLICATION_JSON)
                 .param("url", url)
-                .param("type", type)
+                .param("type", ParsingType.ALL_TEXT.name())
                 .param("unit", unit))
                 // .andDo(print())
                 //then


### PR DESCRIPTION
- 기존에 int로 처리하던 것을 명시적으로 String받도록.
- type자체는 String 으로 변경하고,
validation을 enum활용해서 처리하도록 구현